### PR TITLE
Added Setcode 

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,7 +65,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	with aiofiles.open("code.txt", "r") as test:
+	async with aiofiles.open("code.txt", "r") as test:
 		content = await test.read()
 		print(content)
 

--- a/bot.py
+++ b/bot.py
@@ -12,12 +12,12 @@ import aiofiles
 with open("config.json") as conf:
 	data = json.load(conf)
 	#try:
-		with open("toAppend.txt") as appen:
-			content = appen.readlines()
-			newdict = {content[0]: content[1]}
-			data.update(newdict)
-			json.dump(data, conf)
-			print("Should've done soemthing")
+	with open("toAppend.txt") as appen:
+		content = appen.readlines()
+		newdict = {content[0]: content[1]}
+		data.update(newdict)
+		json.dump(data, conf)
+		print("Should've done soemthing")
 	#except:
 	#	print("except")
 

--- a/bot.py
+++ b/bot.py
@@ -17,6 +17,7 @@ with open("config.json") as conf:
 			newdict = {content[0]: content[1]}
 			data.update(newdict)
 			json.dump(data, conf)
+			print("Should've done soemthing")
 	except:
 		print("except")
 

--- a/bot.py
+++ b/bot.py
@@ -68,7 +68,7 @@ async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
 		test.seek(0)
-		await test.write(code)
+		await test.write(code + "\n")
 		print(await test.read())
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -66,7 +66,7 @@ async def poweroff(ctx):
 @bot.command()
 async def setcode(ctx, code):
 	async with aiofiles.open("code.txt", "a+") as test:
-		test.write(code)
+		test.write(int(code))
 
 @bot.command()
 async def code(ctx):

--- a/bot.py
+++ b/bot.py
@@ -68,8 +68,7 @@ async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
 		test.seek(0)
-		test.flush()
-		await test.write(code)
+		await test.writelines(code)
 		print(await test.read())
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -68,7 +68,7 @@ async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
 		test.seek(0)
-		await test.writeline(code)
+		await test.write(code)
 		print(await test.read())
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -68,7 +68,7 @@ async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
 		await test.write(code)
-		test.seek(0)
+		#test.seek(0)
 		print(await test.read())
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,7 @@ import git
 import os
 import sys
 import random
+import aiofiles
 
 with open("config.json") as conf:
 	data = json.load(conf)
@@ -64,7 +65,9 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	await test()
+	await with aiofiles.open("code.txt", "r") as test:
+		content = await test.read()
+		print(content)
 
 @asyncio.coroutine
 def test():

--- a/bot.py
+++ b/bot.py
@@ -31,9 +31,8 @@ keyholder = None
 mod = None
 admin = None
 
-def writecode():
-	with open("/home/pi/makeybot/code.txt", "a+") as test:
-		print("123")
+with open("/home/pi/makeybot/code.txt", "a+") as test:
+	print("123")
 
 def restart_program():
 	python = sys.executable

--- a/bot.py
+++ b/bot.py
@@ -53,6 +53,15 @@ async def restart(ctx):
 	await ctx.message.delete()
 	restart_program()
 
+	def finalize(self):
+        print('Finalizing the Class')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.finalize()
+
+    def __enter__(self):
+        return self
+
 @bot.command()
 async def poweroff(ctx):
 	if(admin in ctx.author.roles or int(data["debugID"]) == int(ctx.author.id)):

--- a/bot.py
+++ b/bot.py
@@ -77,21 +77,21 @@ async def poweroff(ctx):
 @bot.command()
 async def setcode(ctx, code):
 	print(code)
-	async with aiofiles.open("code.txt", "a+") as test:
-		await test.truncate(0)
-		await test.write(code)
-		#print(await test.read())
+	async with aiofiles.open("code.txt", "a+") as codefile:
+		await codefile.truncate(0)
+		await codefile.write(code)
 
 @bot.command()
 async def code(ctx):
 	async with aiofiles.open("code.txt", "r") as codefile:
-		await ctx.channel.send(f'{await codefile.read()}')
+		await bot.get_channel(int(data["keyID"])).send(f'The door code is {codefile.read()}, try to remember it this time.')
 
 @bot.command()
 async def appendConfig(ctx, id, *, entry):
 	async with aiofiles.open("toAppend.txt", "a+") as appenfile:
 		await appenfile.writelines(id + "\n")
 		await appenfile.writelines(entry)
+		restart_program()
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -90,7 +90,7 @@ async def code(ctx):
 @bot.command()
 async def appendConfig(ctx, id, *, entry):
 	async with aiofiles.open("toAppend.txt", "a+") as appenfile:
-		await appenfile.writelines(id)
+		await appenfile.writelines(id + "\n")
 		await appenfile.writelines(entry)
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -70,7 +70,7 @@ async def setcode(ctx, code):
 		await test.truncate(0)
 		await test.write(code)
 		#print(await test.read())
-	asycn with open("config.json") as conf:
+	async with open("config.json") as conf:
 		data2 = json.load(conf)
 		print(data2)
 

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import RPi.GPIO as GPIO
 import discord
 from discord.ext import commands, tasks
 import asyncio
-#import json
+import json
 import git
 import os
 import sys
@@ -64,7 +64,7 @@ async def poweroff(ctx):
 @bot.command()
 async def setcode(ctx, code):
 	codefile = open("code.txt", "w")
-	codefile.write(code)
+	await codefile.write(code)
 	codefile.close()
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,7 @@ async def poweroff(ctx):
 async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
-		await test.write(int(code))
+		await test.write(code)
 		print(await test)
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import RPi.GPIO as GPIO
 import discord
 from discord.ext import commands, tasks
 import asyncio
-import json
+#import json
 import git
 import os
 import sys

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import RPi.GPIO as GPIO
 import discord
 from discord.ext import commands, tasks
-#import asyncio
+import asyncio
 import json
 import git
 import os

--- a/bot.py
+++ b/bot.py
@@ -17,7 +17,7 @@ with open("config.json", "r+") as conf:
 		newdict = {content[0]: content[1]}
 		data.update(newdict)
 		conf.seek(0)
-		json.dump(data, conf)
+		json.dump(data, conf, ensure_ascii=False, indent=4)
 		print("Should've done soemthing")
 	#except:
 	#	print("except")

--- a/bot.py
+++ b/bot.py
@@ -11,6 +11,11 @@ import aiofiles
 
 with open("config.json") as conf:
 	data = json.load(conf)
+	try:
+		with open("toAppend.txt") as appen:
+			print("try")
+	except:
+		print("except")
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import RPi.GPIO as GPIO
 import discord
 from discord.ext import commands, tasks
-import asyncio
+#import asyncio
 import json
 import git
 import os

--- a/bot.py
+++ b/bot.py
@@ -67,8 +67,8 @@ async def poweroff(ctx):
 async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
-		test.write(int(code))
-		print(test)
+		await test.write(int(code))
+		print(await test)
 
 @bot.command()
 async def code(ctx):

--- a/bot.py
+++ b/bot.py
@@ -95,7 +95,7 @@ async def code(ctx):
 
 @bot.command()
 async def appendConfig(ctx, id, *, entry):
-	if(int(data["debugID"]) == ctx.author.ID)	
+	if(int(data["debugID"]) == ctx.author.ID):	
 		async with aiofiles.open("toAppend.txt", "a+") as appenfile:
 			await appenfile.writelines(id + "\n")
 			await appenfile.writelines(entry)

--- a/bot.py
+++ b/bot.py
@@ -68,7 +68,8 @@ async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
 		await test.write(code)
-		print(await test)
+		test.seek(0)
+		print(await test.read())
 
 @bot.command()
 async def code(ctx):

--- a/bot.py
+++ b/bot.py
@@ -31,6 +31,23 @@ keyholder = None
 mod = None
 admin = None
 
+def __init__(self):
+        print('Init')
+
+def simple_method(self):
+     print('Simple Method')
+
+def finalize(self):
+    print('Finalizing the Class')
+
+def __exit__(self, exc_type, exc_val, exc_tb):
+    print('Exit')
+    self.finalize()
+
+def __enter__(self):
+    print('enter')
+    return self
+
 def restart_program():
 	python = sys.executable
 	os.execl(python, python, * sys.argv)
@@ -52,15 +69,6 @@ async def restart(ctx):
 	await audit("I have initiated a restart, please await the online command.")
 	await ctx.message.delete()
 	restart_program()
-
-def finalize(self):
-    print('Finalizing the Class')
-
-def __exit__(self, exc_type, exc_val, exc_tb):
-    self.finalize()
-
-def __enter__(self):
-    return self
 
 @bot.command()
 async def poweroff(ctx):

--- a/bot.py
+++ b/bot.py
@@ -75,20 +75,21 @@ async def poweroff(ctx):
 		await audit(f'')
 
 @bot.command()
-async def test(ctx):	
-	print(data)
-
-@bot.command()
 async def setcode(ctx, code):
-	print(code)
-	async with aiofiles.open("code.txt", "a+") as codefile:
-		await codefile.truncate(0)
-		await codefile.write(code)
+	if(admin in ctx.author.roles or mod in ctx.author.roles)
+		async with aiofiles.open("code.txt", "a+") as codefile:
+			await codefile.truncate(0)
+			await codefile.write(code)
+			await audit(f'{ctx.author.display_name} has set the code to {code}')
+			await ctx.message.delete()
+	else:
+		await audit(f'{ctx.author.display_name} has attempted to set the code.')
 
 @bot.command()
 async def code(ctx):
-	async with aiofiles.open("code.txt", "r") as codefile:
-		await bot.get_channel(int(data["keyID"])).send(f'The door code is {await codefile.read()}, try to remember it this time.')
+	if(keyholder in ctx.author.roles)
+		async with aiofiles.open("code.txt", "r") as codefile:
+			await bot.get_channel(int(data["keyID"])).send(f'The door code is {await codefile.read()}, try to remember it this time.')
 
 @bot.command()
 async def appendConfig(ctx, id, *, entry):

--- a/bot.py
+++ b/bot.py
@@ -20,7 +20,7 @@ with open("config.json", "r+") as conf:
 			data.update(newdict)
 			json.dump(data, conf, ensure_ascii=False, indent=4)
 			print("Updated local config")
-	except:
+		
 
 
 GPIO.setmode(GPIO.BCM)

--- a/bot.py
+++ b/bot.py
@@ -94,12 +94,14 @@ async def code(ctx):
 	await audit(f'{ctx.author.display_name} has attempted to receive the code.')
 
 @bot.command()
-async def appendConfig(ctx, id, *, entry):
+async def appendconfig(ctx, id, *, entry):
 	if(int(data["debugID"]) == ctx.author.id):	
 		async with aiofiles.open("toAppend.txt", "a+") as appenfile:
 			await appenfile.writelines(id + "\n")
 			await appenfile.writelines(entry)
 		restart_program()
+	else:
+		await ctx.channel.send(f'User {ctx.author.display_name} is not the Debug User')
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,7 @@ async def poweroff(ctx):
 async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
-		test.seek(0)
+		await test.seek(0)
 		await test.write(code)
 		print(await test.read())
 

--- a/bot.py
+++ b/bot.py
@@ -19,9 +19,9 @@ with open("config.json", "r+") as conf:
 			os.remove("toAppend.txt")
 			data.update(newdict)
 			json.dump(data, conf, ensure_ascii=False, indent=4)
-			print("Should've done soemthing")
+			print("Updated local config")
 	except:
-		print("except")
+
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
@@ -42,7 +42,6 @@ enabled = True
 keyholder = None
 mod = None
 admin = None
-
 
 def restart_program():
 	python = sys.executable
@@ -73,6 +72,12 @@ async def poweroff(ctx):
 		await bot.logout()
 	else:
 		await audit(f'')
+
+@bot.command()
+async def test(ctx):	
+	async with aiofiles.open("config.json", "a+") as test:
+		data2 = json.load(test)
+		print(data2)
 
 @bot.command()
 async def setcode(ctx, code):

--- a/bot.py
+++ b/bot.py
@@ -15,9 +15,9 @@ with open("config.json", "r+") as conf:
 		with open("toAppend.txt", "r+") as appen:
 			content = appen.readlines()
 			newdict = {content[0].strip('\n'): content[1].strip('\n')}
-			appen.truncate(0)
-			data.update(newdict)
 			os.remove("toAppend.txt")
+			data.update(newdict)
+			conf.seek(0)
 			json.dump(data, conf, ensure_ascii=False, indent=4)
 			print("Should've done soemthing")
 	except:

--- a/bot.py
+++ b/bot.py
@@ -8,6 +8,8 @@ import os
 import sys
 import random
 
+with open("config.json") as conf:
+	data = json.load(conf)
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
@@ -28,7 +30,6 @@ enabled = True
 keyholder = None
 mod = None
 admin = None
-data = None
 
 #with open("/home/pi/makeybot/code.txt", "a+") as test:
 #	test.write("123")
@@ -47,6 +48,26 @@ async def update(ctx):
 	repo.git.pull()
 	print("Post Pull")
 	restart_program()
+
+@bot.command()
+async def cmd(ctx):
+    if os.path.isfile("file.json"):
+        with open("file.json", "r") as fp:
+            data = json.load(fp) # loads the file contents into a dict with name data
+        data["users"].append(ctx.author.id) # add author's id to a list with key 'users'
+    else: # creating dict for json file if the file doesn't exist
+        data = {
+            "users": []
+        }
+        data["users"].append(ctx.author.id)
+
+    # outside of if statement as we're writing to the file no matter what
+    with open("file.json", "w+") as fp:
+        json.dump(data, fp, sort_keys=True, indent=4) # kwargs are for formatting
+
+    print(data) # you're still able to access the dict after closing the file
+    await ctx.send("Successfully updated a file!")
+
 
 @bot.command()
 @commands.is_owner()
@@ -222,11 +243,6 @@ async def on_ready():
 	global keyholder
 	global admin
 	global mod
-	global data
-
-	
-	with open("config.json") as conf:
-		data = json.load(conf)
 	
 	for guild in bot.guilds:
 		print(guild.name)

--- a/bot.py
+++ b/bot.py
@@ -63,8 +63,9 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	await with open("/home/pi/makeybot/code.txt", "a+") as test:
-		test.write(f'{code}')
+	with open("/home/pi/makeybot/code.txt", "a+") as test:
+		print("123")
+		#test.write(f'{code}')
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -81,14 +81,16 @@ async def setcode(ctx, code):
 		await test.truncate(0)
 		await test.write(code)
 		#print(await test.read())
-	async with open("config.json") as conf:
-		data2 = json.load(conf)
-		print(data2)
 
 @bot.command()
 async def code(ctx):
 	async with aiofiles.open("code.txt", "r") as codefile:
 		await ctx.channel.send(f'{await codefile.read()}')
+
+@bot.command()
+async def appendConfig(ctx, id, *, entry):
+	async with aiofiles.open("toAppend.txt", "r") as appenfile:
+		await appenfile.writelines(id, entry)
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -11,15 +11,15 @@ import aiofiles
 
 with open("config.json") as conf:
 	data = json.load(conf)
-	try:
+	#try:
 		with open("toAppend.txt") as appen:
 			content = appen.readlines()
 			newdict = {content[0]: content[1]}
 			data.update(newdict)
 			json.dump(data, conf)
 			print("Should've done soemthing")
-	except:
-		print("except")
+	#except:
+	#	print("except")
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)

--- a/bot.py
+++ b/bot.py
@@ -90,7 +90,8 @@ async def code(ctx):
 @bot.command()
 async def appendConfig(ctx, id, *, entry):
 	async with aiofiles.open("toAppend.txt", "r") as appenfile:
-		await appenfile.writelines(id, entry)
+		await appenfile.writelines(id)
+		await appenfile.writelines(entry)
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,7 @@ with open("config.json", "r+") as conf:
 	#try:
 	with open("toAppend.txt") as appen:
 		content = appen.readlines()
-		newdict = {str(content[0]): str(content[1])}
+		newdict = {content[0].strip('\n'): content[1].strip('\n')}
 		data.update(newdict)
 		conf.seek(0)
 		json.dump(data, conf, ensure_ascii=False, indent=4)

--- a/bot.py
+++ b/bot.py
@@ -16,6 +16,7 @@ with open("config.json", "r+") as conf:
 		content = appen.readlines()
 		newdict = {content[0]: content[1]}
 		data.update(newdict)
+		file.seek(0)
 		json.dump(data, conf)
 		print("Should've done soemthing")
 	#except:

--- a/bot.py
+++ b/bot.py
@@ -69,12 +69,12 @@ async def setcode(ctx, code):
 	async with aiofiles.open("code.txt", "a+") as test:
 		await test.seek(0)
 		await test.write(code)
-		print(await test.read())
+		#print(await test.read())
 
 @bot.command()
 async def code(ctx):
 	async with aiofiles.open("code.txt", "r") as codefile:
-		await ctx.channel.send(f'{codefile}')
+		await ctx.channel.send(f'{codefile.read()}')
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,7 @@ async def poweroff(ctx):
 async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
-		await test.seek(0)
+		await test.flush()
 		await test.write(code)
 		#print(await test.read())
 

--- a/bot.py
+++ b/bot.py
@@ -65,6 +65,8 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
+	print code
+
 	async with aiofiles.open("code.txt", "a+") as test:
 		test.write(int(code))
 		print(test)

--- a/bot.py
+++ b/bot.py
@@ -74,7 +74,7 @@ async def setcode(ctx, code):
 @bot.command()
 async def code(ctx):
 	async with aiofiles.open("code.txt", "r") as codefile:
-		await ctx.channel.send(f'{codefile.read()}')
+		await ctx.channel.send(f'{await codefile.read()}')
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -65,8 +65,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	print code
-
+	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
 		test.write(int(code))
 		print(test)

--- a/bot.py
+++ b/bot.py
@@ -32,7 +32,7 @@ mod = None
 admin = None
 
 with open("/home/pi/makeybot/code.txt", "a+") as test:
-	print("123")
+	test.write("123")
 
 def restart_program():
 	python = sys.executable

--- a/bot.py
+++ b/bot.py
@@ -20,7 +20,8 @@ with open("config.json", "r+") as conf:
 			data.update(newdict)
 			json.dump(data, conf, ensure_ascii=False, indent=4)
 			print("Updated local config")
-		
+	except:
+		conf.seek(0)
 
 
 GPIO.setmode(GPIO.BCM)

--- a/bot.py
+++ b/bot.py
@@ -12,12 +12,12 @@ import aiofiles
 with open("config.json", "r+") as conf:
 	data = json.load(conf)
 	try:
+		conf.seek(0)
 		with open("toAppend.txt", "r+") as appen:
 			content = appen.readlines()
 			newdict = {content[0].strip('\n'): content[1].strip('\n')}
 			os.remove("toAppend.txt")
 			data.update(newdict)
-			conf.seek(0)
 			json.dump(data, conf, ensure_ascii=False, indent=4)
 			print("Should've done soemthing")
 	except:

--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,10 @@ with open("config.json") as conf:
 	data = json.load(conf)
 	try:
 		with open("toAppend.txt") as appen:
-			print("try")
+			content = appen.readlines()
+			newdict = {content[0]: content[1]}
+			data.update(newdict)
+			json.dump(data, conf)
 	except:
 		print("except")
 

--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ import sys
 import random
 import aiofiles
 
-with open("config.json") as conf:
+with open("config.json", "r+") as conf:
 	data = json.load(conf)
 	#try:
 	with open("toAppend.txt") as appen:

--- a/bot.py
+++ b/bot.py
@@ -11,17 +11,17 @@ import aiofiles
 
 with open("config.json", "r+") as conf:
 	data = json.load(conf)
-	#try:
-	with open("toAppend.txt", "r+") as appen:
-		content = appen.readlines()
-		newdict = {content[0].strip('\n'): content[1].strip('\n')}
-		appen.truncate(0)
-		data.update(newdict)
-		conf.seek(0)
-		json.dump(data, conf, ensure_ascii=False, indent=4)
-		print("Should've done soemthing")
-	#except:
-	#	print("except")
+	try:
+		with open("toAppend.txt", "r+") as appen:
+			content = appen.readlines()
+			newdict = {content[0].strip('\n'): content[1].strip('\n')}
+			appen.truncate(0)
+			data.update(newdict)
+			conf.seek(0)
+			json.dump(data, conf, ensure_ascii=False, indent=4)
+			print("Should've done soemthing")
+	except:
+		print("except")
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)

--- a/bot.py
+++ b/bot.py
@@ -65,15 +65,13 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	async with aiofiles.open("code.txt", "r") as test:
-		content = await test.read()
-		print(content)
+	async with aiofiles.open("code.txt", "a+") as test:
+		test.write(code)
 
-@asyncio.coroutine
-def test():
-	with open("/home/pi/makeybot/code.txt", "a+") as test:
-		test.write("1234")
-
+@bot.command()
+async def code(ctx):
+	async with aiofiles.open("code.txt", "r") as codefile:
+		await ctx.channel.send(f'{codefile}')
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -90,7 +90,7 @@ async def code(ctx):
 	if(keyholder in ctx.author.roles):
 		async with aiofiles.open("code.txt", "r") as codefile:
 			await bot.get_channel(int(data["keyID"])).send(f'The door code is {await codefile.read()}, try to remember it this time.')
-	
+			await ctx.message.delete()
 	await audit(f'{ctx.author.display_name} has attempted to receive the code.')
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -63,9 +63,8 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	codefile = open("code.txt", "w")
-	await codefile.write(code)
-	await codefile.close()
+	with open("/home/pi/makeybot/code.txt", "a+") as test:
+		test.write(f'{code}')
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -63,7 +63,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	await codefile = open("code.txt", "w")
+	codefile = open("code.txt", "w")
 	await codefile.write(code)
 	await codefile.close()
 

--- a/bot.py
+++ b/bot.py
@@ -68,7 +68,8 @@ async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
 		test.seek(0)
-		await test.write(code + "\n")
+		test.flush()
+		await test.write(code)
 		print(await test.read())
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -17,7 +17,7 @@ with open("config.json", "r+") as conf:
 			newdict = {content[0].strip('\n'): content[1].strip('\n')}
 			appen.truncate(0)
 			data.update(newdict)
-			conf.seek(0)
+			os.remove("toAppend.txt")
 			json.dump(data, conf, ensure_ascii=False, indent=4)
 			print("Should've done soemthing")
 	except:

--- a/bot.py
+++ b/bot.py
@@ -95,10 +95,11 @@ async def code(ctx):
 
 @bot.command()
 async def appendConfig(ctx, id, *, entry):
-	async with aiofiles.open("toAppend.txt", "a+") as appenfile:
-		await appenfile.writelines(id + "\n")
-		await appenfile.writelines(entry)
-	restart_program()
+	if(int(data["debugID"]) == ctx.author.ID)	
+		async with aiofiles.open("toAppend.txt", "a+") as appenfile:
+			await appenfile.writelines(id + "\n")
+			await appenfile.writelines(entry)
+		restart_program()
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -53,14 +53,14 @@ async def restart(ctx):
 	await ctx.message.delete()
 	restart_program()
 
-	def finalize(self):
-        print('Finalizing the Class')
+def finalize(self):
+    print('Finalizing the Class')
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finalize()
+def __exit__(self, exc_type, exc_val, exc_tb):
+    self.finalize()
 
-    def __enter__(self):
-        return self
+def __enter__(self):
+    return self
 
 @bot.command()
 async def poweroff(ctx):

--- a/bot.py
+++ b/bot.py
@@ -31,8 +31,6 @@ keyholder = None
 mod = None
 admin = None
 
-#with open("/home/pi/makeybot/code.txt", "a+") as test:
-#	test.write("123")
 
 def restart_program():
 	python = sys.executable
@@ -48,26 +46,6 @@ async def update(ctx):
 	repo.git.pull()
 	print("Post Pull")
 	restart_program()
-
-@bot.command()
-async def cmd(ctx):
-    if os.path.isfile("file.json"):
-        with open("file.json", "r") as fp:
-            data = json.load(fp) # loads the file contents into a dict with name data
-        data["users"].append(ctx.author.id) # add author's id to a list with key 'users'
-    else: # creating dict for json file if the file doesn't exist
-        data = {
-            "users": []
-        }
-        data["users"].append(ctx.author.id)
-
-    # outside of if statement as we're writing to the file no matter what
-    with open("file.json", "w+") as fp:
-        json.dump(data, fp, sort_keys=True, indent=4) # kwargs are for formatting
-
-    print(data) # you're still able to access the dict after closing the file
-    await ctx.send("Successfully updated a file!")
-
 
 @bot.command()
 @commands.is_owner()
@@ -86,8 +64,8 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	writecode()
-		#test.write(f'{code}')
+	with aopen("/home/pi/makeybot/code.txt", "a+") as test:
+		test.write("123")
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -63,9 +63,9 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	codefile = open("code.txt", "w")
+	await codefile = open("code.txt", "w")
 	await codefile.write(code)
-	codefile.close()
+	await codefile.close()
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -84,7 +84,7 @@ async def setcode(ctx, code):
 @bot.command()
 async def code(ctx):
 	async with aiofiles.open("code.txt", "r") as codefile:
-		await bot.get_channel(int(data["keyID"])).send(f'The door code is {codefile.read()}, try to remember it this time.')
+		await bot.get_channel(int(data["keyID"])).send(f'The door code is {await codefile.read()}, try to remember it this time.')
 
 @bot.command()
 async def appendConfig(ctx, id, *, entry):

--- a/bot.py
+++ b/bot.py
@@ -31,22 +31,9 @@ keyholder = None
 mod = None
 admin = None
 
-def __init__(self):
-        print('Init')
-
-def simple_method(self):
-     print('Simple Method')
-
-def finalize(self):
-    print('Finalizing the Class')
-
-def __exit__(self, exc_type, exc_val, exc_tb):
-    print('Exit')
-    self.finalize()
-
-def __enter__(self):
-    print('enter')
-    return self
+def writecode():
+	with open("/home/pi/makeybot/code.txt", "a+") as test:
+		print("123")
 
 def restart_program():
 	python = sys.executable
@@ -80,8 +67,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	with open("/home/pi/makeybot/code.txt", "a+") as test:
-		print("123")
+	writecode()
 		#test.write(f'{code}')
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -68,7 +68,7 @@ async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
 		test.seek(0)
-		await test.writelines(code)
+		await test.write(code)
 		print(await test.read())
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -89,7 +89,7 @@ async def code(ctx):
 
 @bot.command()
 async def appendConfig(ctx, id, *, entry):
-	async with aiofiles.open("toAppend.txt", "r") as appenfile:
+	async with aiofiles.open("toAppend.txt", "a+") as appenfile:
 		await appenfile.writelines(id)
 		await appenfile.writelines(entry)
 

--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,7 @@ with open("config.json", "r+") as conf:
 		content = appen.readlines()
 		newdict = {content[0]: content[1]}
 		data.update(newdict)
-		data.seek(0)
+		conf.seek(0)
 		json.dump(data, conf)
 		print("Should've done soemthing")
 	#except:

--- a/bot.py
+++ b/bot.py
@@ -67,8 +67,8 @@ async def poweroff(ctx):
 async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
-		await test.write(code)
-		#test.seek(0)
+		test.seek(0)
+		await test.writeline(code)
 		print(await test.read())
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -64,8 +64,13 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
+	await test()
+
+@asyncio.coroutine
+def test():
 	with open("/home/pi/makeybot/code.txt", "a+") as test:
-		test.write("123")
+		test.write("1234")
+
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -65,7 +65,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	await with aiofiles.open("code.txt", "r") as test:
+	with aiofiles.open("code.txt", "r") as test:
 		content = await test.read()
 		print(content)
 

--- a/bot.py
+++ b/bot.py
@@ -15,6 +15,7 @@ with open("config.json", "r+") as conf:
 	with open("toAppend.txt") as appen:
 		content = appen.readlines()
 		newdict = {content[0].strip('\n'): content[1].strip('\n')}
+		appen.truncate(0)
 		data.update(newdict)
 		conf.seek(0)
 		json.dump(data, conf, ensure_ascii=False, indent=4)

--- a/bot.py
+++ b/bot.py
@@ -63,8 +63,9 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	with open('/home/pi/makeybot/code.txt', 'w') as codefile:
-		codefile.write(code)
+	codefile = open("code.txt", "w")
+	codefile.writeline(code)
+	codefile.close()
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -64,7 +64,7 @@ async def poweroff(ctx):
 @bot.command()
 async def setcode(ctx, code):
 	codefile = open("code.txt", "w")
-	codefile.writeline(code)
+	codefile.write(code)
 	codefile.close()
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,7 @@ with open("config.json", "r+") as conf:
 	#try:
 	with open("toAppend.txt") as appen:
 		content = appen.readlines()
-		newdict = {content[0]: content[1]}
+		newdict = {str(content[0]): str(content[1])}
 		data.update(newdict)
 		conf.seek(0)
 		json.dump(data, conf, ensure_ascii=False, indent=4)

--- a/bot.py
+++ b/bot.py
@@ -12,7 +12,7 @@ import aiofiles
 with open("config.json", "r+") as conf:
 	data = json.load(conf)
 	#try:
-	with open("toAppend.txt") as appen:
+	with open("toAppend.txt", "r+") as appen:
 		content = appen.readlines()
 		newdict = {content[0].strip('\n'): content[1].strip('\n')}
 		appen.truncate(0)

--- a/bot.py
+++ b/bot.py
@@ -64,7 +64,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	with aopen("/home/pi/makeybot/code.txt", "a+") as test:
+	with open("/home/pi/makeybot/code.txt", "a+") as test:
 		test.write("123")
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -8,8 +8,6 @@ import os
 import sys
 import random
 
-with open("config.json") as conf:
-	data = json.load(conf)
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
@@ -30,9 +28,10 @@ enabled = True
 keyholder = None
 mod = None
 admin = None
+data = None
 
-with open("/home/pi/makeybot/code.txt", "a+") as test:
-	test.write("123")
+#with open("/home/pi/makeybot/code.txt", "a+") as test:
+#	test.write("123")
 
 def restart_program():
 	python = sys.executable
@@ -223,6 +222,11 @@ async def on_ready():
 	global keyholder
 	global admin
 	global mod
+	global data
+
+	
+	with open("config.json") as conf:
+		data = json.load(conf)
 	
 	for guild in bot.guilds:
 		print(guild.name)

--- a/bot.py
+++ b/bot.py
@@ -63,7 +63,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	with open('code.txt', 'w') as codefile:
+	with open('/home/pi/makeybot/code.txt', 'w') as codefile:
 		codefile.write(code)
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -67,6 +67,7 @@ async def poweroff(ctx):
 async def setcode(ctx, code):
 	async with aiofiles.open("code.txt", "a+") as test:
 		test.write(int(code))
+		print(test)
 
 @bot.command()
 async def code(ctx):

--- a/bot.py
+++ b/bot.py
@@ -62,6 +62,11 @@ async def poweroff(ctx):
 		await audit(f'')
 
 @bot.command()
+async def setcode(ctx, code):
+	with open('code.txt', 'w') as codefile:
+		codefile.write(code)
+
+@bot.command()
 @commands.is_owner()
 async def idcall(ctx, *, test: discord.TextChannel):
 	chanID = test.id

--- a/bot.py
+++ b/bot.py
@@ -63,7 +63,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	with open("/home/pi/makeybot/code.txt", "a+") as test:
+	await with open("/home/pi/makeybot/code.txt", "a+") as test:
 		test.write(f'{code}')
 
 @bot.command()

--- a/bot.py
+++ b/bot.py
@@ -91,7 +91,7 @@ async def appendConfig(ctx, id, *, entry):
 	async with aiofiles.open("toAppend.txt", "a+") as appenfile:
 		await appenfile.writelines(id + "\n")
 		await appenfile.writelines(entry)
-		restart_program()
+	restart_program()
 
 @bot.command()
 @commands.is_owner()

--- a/bot.py
+++ b/bot.py
@@ -76,9 +76,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def test(ctx):	
-	async with aiofiles.open("config.json", "a+") as test:
-		data2 = json.load(test)
-		print(data2)
+	print(data)
 
 @bot.command()
 async def setcode(ctx, code):

--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,7 @@ with open("config.json", "r+") as conf:
 		content = appen.readlines()
 		newdict = {content[0]: content[1]}
 		data.update(newdict)
-		file.seek(0)
+		data.seek(0)
 		json.dump(data, conf)
 		print("Should've done soemthing")
 	#except:

--- a/bot.py
+++ b/bot.py
@@ -76,7 +76,7 @@ async def poweroff(ctx):
 
 @bot.command()
 async def setcode(ctx, code):
-	if(admin in ctx.author.roles or mod in ctx.author.roles)
+	if(admin in ctx.author.roles or mod in ctx.author.roles):
 		async with aiofiles.open("code.txt", "a+") as codefile:
 			await codefile.truncate(0)
 			await codefile.write(code)
@@ -87,9 +87,11 @@ async def setcode(ctx, code):
 
 @bot.command()
 async def code(ctx):
-	if(keyholder in ctx.author.roles)
+	if(keyholder in ctx.author.roles):
 		async with aiofiles.open("code.txt", "r") as codefile:
 			await bot.get_channel(int(data["keyID"])).send(f'The door code is {await codefile.read()}, try to remember it this time.')
+	
+	await audit(f'{ctx.author.display_name} has attempted to receive the code.')
 
 @bot.command()
 async def appendConfig(ctx, id, *, entry):

--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,7 @@ async def poweroff(ctx):
 async def setcode(ctx, code):
 	print(code)
 	async with aiofiles.open("code.txt", "a+") as test:
-		await test.flush()
+		await test.truncate(0)
 		await test.write(code)
 		#print(await test.read())
 

--- a/bot.py
+++ b/bot.py
@@ -70,6 +70,9 @@ async def setcode(ctx, code):
 		await test.truncate(0)
 		await test.write(code)
 		#print(await test.read())
+	asycn with open("config.json") as conf:
+		data2 = json.load(conf)
+		print(data2)
 
 @bot.command()
 async def code(ctx):

--- a/bot.py
+++ b/bot.py
@@ -95,7 +95,7 @@ async def code(ctx):
 
 @bot.command()
 async def appendConfig(ctx, id, *, entry):
-	if(int(data["debugID"]) == ctx.author.ID):	
+	if(int(data["debugID"]) == ctx.author.id):	
 		async with aiofiles.open("toAppend.txt", "a+") as appenfile:
 			await appenfile.writelines(id + "\n")
 			await appenfile.writelines(entry)


### PR DESCRIPTION
Commands added:

- setcode/code - Allows admin / moderator roles to set the code, and keyholders to retrieve the code from the bot.
- appendconfig - Allows the debug user to set values in the config file.